### PR TITLE
feat: support newest lts net6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,29 +1,54 @@
-name: Build
+name: Build_And_Test
 
 on:
   push:
-    branches: [ dev, main ]
+    branches: [ dev, main, 'feat/**' ]
   pull_request:
     branches: [ dev, main ]
 
 jobs:
 
   linux:    
-    name: build on linux
-    runs-on: ubuntu-latest
-    
+    name: build on ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2
+    - name: Setup .NET SDK 6.0.x
+      uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 5.0.x   
+        dotnet-version: 6.0.x 
+    
+    - name: Setup .NET SDK 5.0.x
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 5.0.x 
+
+    - name: Setup .NET SDK 3.1.x
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 3.1.x 
+
     - name: Show dotnet Version
-      run: dotnet --version   
-    - name: Build with dotnet
       run: |
-        dotnet build --configuration Release --source https://api.nuget.org/v3/index.json src/Dtmcli/Dtmcli.csproj
-        dotnet build --configuration Release --source https://api.nuget.org/v3/index.json src/Dtmcli.Tests/Dtmcli.Tests.csproj        
-    - name: Test with dotnet
+        dotnet --list-sdks
+        dotnet --list-runtimes
+
+    - name: Build with dotnet      
       run: |
-        dotnet test src/Dtmcli.Tests/Dtmcli.Tests.csproj --no-restore
+        dotnet build src/Dtmcli/Dtmcli.csproj 
+
+    - name: Run tests on netcoreapp3.1
+      run: |
+        dotnet test --framework=netcoreapp3.1 src/Dtmcli.Tests/Dtmcli.Tests.csproj
+
+    - name: Run tests on net5.0
+      run: |
+        dotnet test --framework=net5.0 src/Dtmcli.Tests/Dtmcli.Tests.csproj
+
+    - name: Run tests on net6.0
+      run: |
+        dotnet test --framework=net6.0 src/Dtmcli.Tests/Dtmcli.Tests.csproj

--- a/.github/workflows/release_unstable.yml
+++ b/.github/workflows/release_unstable.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Build with dotnet
       run: |
         dotnet build --configuration Release --source https://api.nuget.org/v3/index.json src/Dtmcli/Dtmcli.csproj        

--- a/src/Dtmcli.Tests/Dtmcli.Tests.csproj
+++ b/src/Dtmcli.Tests/Dtmcli.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+	<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <!--<Nullable>enable</Nullable>-->
 
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="DbMocker" Version="1.21.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/Dtmcli.Tests/SagaTests.cs
+++ b/src/Dtmcli.Tests/SagaTests.cs
@@ -45,7 +45,7 @@ namespace Dtmcli.Tests
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                var str = await request.Content?.ReadAsStringAsync(cancellationToken) ?? "";
+                var str = await request.Content?.ReadAsStringAsync() ?? "";
 
                 var transBase = System.Text.Json.JsonSerializer.Deserialize<DtmImp.TransBase>(str);
 

--- a/src/Dtmcli/Dtmcli.csproj
+++ b/src/Dtmcli/Dtmcli.csproj
@@ -1,24 +1,41 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
-    <PackageProjectUrl>https://github.com/dtm-labs/dtmcli-csharp</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/dtm-labs/dtmcli-csharp</RepositoryUrl>
-    <AssemblyName>Dtmcli</AssemblyName>
-    <RootNamespace>Dtmcli</RootNamespace>
-    <Description>a c# client for distributed transaction framework dtm. 分布式事务管理器dtm的c#客户端</Description>
-    <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
-    <Authors>geffzhang</Authors>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+		<PackageProjectUrl>https://github.com/dtm-labs/dtmcli-csharp</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/dtm-labs/dtmcli-csharp</RepositoryUrl>
+		<AssemblyName>Dtmcli</AssemblyName>
+		<RootNamespace>Dtmcli</RootNamespace>
+		<Description>a c# client for distributed transaction framework dtm. 分布式事务管理器dtm的c#客户端</Description>
+		<VersionPrefix>0.3.0</VersionPrefix>
+		<VersionSuffix></VersionSuffix>
+		<Authors>geffzhang</Authors>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Dapper" Version="2.0.123" />
+		<PackageReference Include="System.Text.Json" Version="6.0.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Support newest lts version ne6.0
2. Test project add `netcoreapp3.1` and `net6.0` 

After this PR was merged, we will release a stable version of v0.3.0.
